### PR TITLE
Add LDAP authentication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ ARG grafana_version=latest
 FROM grafana/grafana:${grafana_version}
 
 COPY grafana.ini /etc/grafana
+COPY ldap.toml /etc/grafana
 COPY provisioning /etc/grafana/provisioning
 
 RUN /bin/bash

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ DOCKER_REVISION ?= grafana-testing-$(USER)
 DOCKER_TAG = docker-push.ocf.berkeley.edu/grafana:$(DOCKER_REVISION)
 RANDOM_PORT := $(shell expr $$(( 8000 + (`id -u` % 1000) + 2 )))
 
-GF_VERSION := 5.2.3
+GF_VERSION := 5.2.4
 
 .PHONY: dev
 dev: cook-image

--- a/grafana.ini
+++ b/grafana.ini
@@ -3,3 +3,7 @@ viewers_can_edit = true
 
 [auth.anonymous]
 enabled = true
+
+[auth.ldap]
+enabled = true
+config_file = /etc/grafana/ldap.toml

--- a/ldap.toml
+++ b/ldap.toml
@@ -1,0 +1,28 @@
+[[servers]]
+host = "ldap.ocf.berkeley.edu"
+port = 636
+use_ssl = true
+
+bind_dn = "uid=%s,ou=People,dc=OCF,dc=Berkeley,dc=EDU"
+search_filter = "(uid=%s)"
+search_base_dns = ["ou=People,dc=OCF,dc=Berkeley,dc=EDU"]
+group_search_filter = "(&(objectClass=posixGroup)(memberUid=%s))"
+group_search_base_dns = ["ou=Group,dc=OCF,dc=Berkeley,dc=EDU"]
+group_search_filter_user_attribute = "uid"
+
+[servers.attributes]
+username = "uid"
+member_of = "dn"
+
+[[servers.group_mappings]]
+group_dn = "cn=ocfroot,ou=Group,dc=OCF,dc=Berkeley,dc=EDU"
+org_role = "Admin"
+grafana_admin = true
+
+[[servers.group_mappings]]
+group_dn = "cn=ocfstaff,ou=Group,dc=OCF,dc=Berkeley,dc=EDU"
+org_role = "Editor"
+
+[[servers.group_mappings]]
+group_dn = "*"
+org_role = "Viewer"


### PR DESCRIPTION
Now that we have LDAP passthrough, we can let OCF staff log in and experiment with dashboards!

Grafana also lets us divvy roles based on group. Right now I have it configured to give root staffers Admin access, and non-staff OCF users Viewer access (which is effectively the same as being anonymous).