### PR TITLE
Add latest tag when pushing Docker image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 DOCKER_REVISION ?= grafana-testing-$(USER)
 DOCKER_TAG = docker-push.ocf.berkeley.edu/grafana:$(DOCKER_REVISION)
+DOCKER_LATEST = docker-push.ocf.berkeley.edu/grafana:latest
 RANDOM_PORT := $(shell expr $$(( 8000 + (`id -u` % 1000) + 2 )))
 
 GF_VERSION := 5.3.4
@@ -15,4 +16,5 @@ cook-image:
 
 .PHONY: push-image
 push-image:
+	docker tag $(DOCKER_LATEST) $(DOCKER_TAG)
 	docker push $(DOCKER_TAG)


### PR DESCRIPTION
We should really be tagging our recent images as `latest`, since it would make a lot of container stuff simpler.

Based on https://stackoverflow.com/a/31963727, this seems to be the cleanest way to do this. Thoughts? If this looks good, I'll change the rest of our repos to have this.

Resolves ocf.io/rt/6855.