### PR TITLE
remove marathon deploy target

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,5 @@
 servicePipeline(
     upstreamProjects: ['dockers/master'],
-    deployTargets: ['grafana'],
 )
 
 // vim: ft=groovy


### PR DESCRIPTION
Grafana is on Kubernetes now.