### PR TITLE
remove anonymous auth and restrict Viewer permissions

### DIFF
--- a/grafana.ini
+++ b/grafana.ini
@@ -1,11 +1,5 @@
-[users]
-viewers_can_edit = true
-
 [auth]
 oauth_auto_login = true
-
-[auth.anonymous]
-enabled = true
 
 [auth.generic_oauth]
 enabled = true


### PR DESCRIPTION
As we deploy Loki, we should restrict access to these logs. It's thus necessary to remove the ability of arbitrary users to run arbitrary queries.