### PR TITLE
Upgrade to 7.0.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ DOCKER_REVISION ?= grafana-testing-$(USER)
 DOCKER_TAG = docker-push.ocf.berkeley.edu/grafana:$(DOCKER_REVISION)
 RANDOM_PORT := $(shell expr $$(( 8000 + (`id -u` % 1000) + 2 )))
 
-GF_VERSION := 6.7.3
+GF_VERSION := 7.0.0
 
 .PHONY: dev
 dev: cook-image


### PR DESCRIPTION
closes #17 

Might need to be tested, but grafana isn't user-facing so we could also just go for it and revert if necessary.

Also, **permissions in this repository are broken** - I can't push to nonmaster branches like everything else :(