### PR TITLE
Upgrade to 7.0.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ DOCKER_REVISION ?= grafana-testing-$(USER)
 DOCKER_TAG = docker-push.ocf.berkeley.edu/grafana:$(DOCKER_REVISION)
 RANDOM_PORT := $(shell expr $$(( 8000 + (`id -u` % 1000) + 2 )))
 
-GF_VERSION := 7.0.0
+GF_VERSION := 7.0.3
 
 .PHONY: dev
 dev: cook-image


### PR DESCRIPTION
This fixes a security vulnerability: https://grafana.com/blog/2020/06/03/grafana-6.7.4-and-7.0.2-released-with-important-security-fix/